### PR TITLE
Fix:  binary compression of leading 1s produces incorrect VCD output

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -37,6 +37,8 @@ jobs:
       with:
         python-version: '3.x'
     - run: pip install -r test/requirements.txt
+    - name: Install GTKWave
+      run: sudo apt-get update && sudo apt-get install -y gtkwave xvfb
     - name: Build Project
       uses: threeal/cmake-action@v2.0.0
       with:

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: '3.x'
     - run: pip install -r test/requirements.txt
     - name: Install GTKWave
-      run: sudo apt-get update && sudo apt-get install -y gtkwave xvfb
+      run: sudo apt-get update && sudo apt-get install -y gtkwave xvfb x11-apps ffmpeg
     - name: Build Project
       uses: threeal/cmake-action@v2.0.0
       with:

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -51,6 +51,15 @@ jobs:
       uses: threeal/ctest-action@v1.1.0
       with:
          build-config: $BUILD_TYPE
+      env:
+        INTEROP_ARTIFACTS: ${{ github.workspace }}/interop-artifacts
+    - name: Upload Interop Artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: interop-artifacts
+        path: interop-artifacts/
+        if-no-files-found: ignore
     - name: Check Test Coverage
       uses: threeal/gcovr-action@v1.1.0
       with:

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -33,6 +33,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
           submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - run: pip install -r test/requirements.txt
     - name: Build Project
       uses: threeal/cmake-action@v2.0.0
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ $RECYCLE.BIN/
 .TemporaryItems
 ehthumbs.db
 Thumbs.db
+
+.cache/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ BSD 3-Clause License. See LICENSE.
 
 Signals are traced using the templated `vcd_tracer::value<>`
 class. The data type that can be traced is limited to fundamental
-types. The bit size can be specified independently to the 
+types. The bit size can be specified independently to the
 
 ~~~
    vcd_tracer::value<bool> clock1;
@@ -60,7 +60,7 @@ be traced.
    vcd_tracer::module digital(dumper.root, "digital");
    vcd_tracer::module bus(digital, "bus");
    vcd_tracer::module analog(dumper.root, "analog");
-   
+
    // The elaboration of signals inside of the module hierarchy
    digital.elaborate(clock1, "clk");
    analog.elaborate(sine_wave, "wave");
@@ -75,7 +75,7 @@ elaborated the header can be finalized.
 
 ~~~
    std::ofstream fout(fout_name);
-   dumper.finalize_header(fout, 
+   dumper.finalize_header(fout,
        std::chrono::system_clock::from_time_t(0));
 ~~~
 
@@ -94,7 +94,7 @@ Values are written to file when the `time_update_abs()` or
 `time_update_delta()` methods are called.
 
 ~~~
-   dumper.time_update_abs(fout, 
+   dumper.time_update_abs(fout,
         std::chrono::nanoseconds{ TICK_NS * i });
 ~~~
 
@@ -166,6 +166,11 @@ The library is implemented in C++17.
 This library is designed to use dependency injection rather than a C++
 class hierarchy for defining the relation between design hierarchy and
 variables. This allows the module and signal hierarchy creation to be de-coupled from tracing.
+
+## Testing
+
+- See [test/README.md](test/README.md) for details on unit tests, constexpr tests, and interoperability tests against pyvcd and GTKWave.
+- The [GitHub Actions workflow](.github/workflows/build_cmake.yml) runs all tests and uploads interop artifacts (VCD, CSV, and GTKWave screenshot) downloadable from the workflow run's Artifacts section.
 
 ## Related Projects
 

--- a/example/signals.cpp
+++ b/example/signals.cpp
@@ -1,11 +1,11 @@
-/*  
+/*
  *  C++ VCD Tracer Library Signal Definition and Tracing Example.
  *
  *  For more information see https://github.com/nakane1chome/cpp-vcd-tracer
  *
  * Copyright (c) 2022, Philip Mulholland
  * All rights reserved.
- * 
+ *
  * Using the  BSD 3-Clause License
  *
  * See LICENSE for license details.
@@ -41,19 +41,19 @@ int main(int argc, const char **argv) {
 
 
     // The top module defines the base of the signal hierarchy
-    // It also owns 
+    // It also owns
     vcd_tracer::top dumper("root");
 
     // Define a module hierarchy and associate signals with it
     // This elaboration is indepdent of the signal definition above
-    // so the modules can be deallocated 
+    // so the modules can be deallocated
     {
         // Create two child domains.
         // Any number
         vcd_tracer::module digital(dumper.root, "digital");
         vcd_tracer::module bus(digital, "bus");
         vcd_tracer::module analog(dumper.root, "analog");
-        
+
         // The elaboration of signals inside of the module hierarchy
         digital.elaborate(clock1, "clk");
         analog.elaborate(sine_wave, "wave");
@@ -70,12 +70,12 @@ int main(int argc, const char **argv) {
 
         // Finalize signals before tracing11
         // The VCD format does not allow dynamic signal definition.
-        dumper.finalize_header(fout, 
+        dumper.finalize_header(fout,
                                std::chrono::system_clock::from_time_t(0));
 
         unsigned int mem_addr = 0;
         burst.set(1);
-        
+
         for (unsigned int i=0; i<CYCLES; i++) {
 
             // div2
@@ -86,7 +86,7 @@ int main(int argc, const char **argv) {
             // Waveform
             const double seconds = static_cast<double>(i) * 1e-9 * TICK_NS;
             sine_wave.set( WAVE_BIAS_V + (WAVE_AMPL_V * sin(seconds * WAVE_FREQ_HZ * 2.0 * M_PI)));
-            
+
             // Memory read write
             if ((i % 100)==20) {
                 // Write
@@ -104,9 +104,9 @@ int main(int argc, const char **argv) {
             addr.set(static_cast<uint16_t>(mem_addr&0xFFFF));
             data.set(memory[mem_addr]);
 
-            
+
             dumper.time_update_abs(fout, std::chrono::nanoseconds{ TICK_NS * i });
-            
+
         }
 
     }

--- a/src/vcd_tracer.cpp
+++ b/src/vcd_tracer.cpp
@@ -300,23 +300,15 @@ namespace vcd_tracer {
             }
             else {
                 T mask = static_cast<T>(1) << (bit_size - 1);
-                bool prev_bit = (value & mask) != 0;
                 // Only compress leading 0s; per IEEE 1364, VCD viewers
                 // zero-fill shorter values, so leading 1s must be kept.
-                bool compress = !prev_bit;
-                for (int i = bit_size - 2; i >= 0; i--) {
+                while ((mask != static_cast<T>(1)) & ((value & mask) == 0)) {
                     mask = mask >> 1;
-                    const bool this_bit = (value & mask) != 0;
-                    if (compress && (this_bit == prev_bit)) {
-                        // Compress leading zeros..
-                    }
-                    else {
-                        compress = false;
-                        out << (prev_bit ? "1" : "0");
-                    }
-                    prev_bit = this_bit;
                 }
-                out << (prev_bit ? "1" : "0");
+                while (mask != 0) {
+                    out << ((value & mask) != 0) ? "1" : "0";
+                    mask = mask >> 1;
+                }
             }
             out << " " << _scope.identifier << "\n";
         }

--- a/src/vcd_tracer.cpp
+++ b/src/vcd_tracer.cpp
@@ -1,11 +1,11 @@
-/* 
+/*
  *  C++ VCD Tracer Library
  *
  *  For more information see https://github.com/nakane1chome/cpp-vcd-tracer
  *
  * Copyright (c) 2022, Philip Mulholland
  * All rights reserved.
- * 
+ *
  * Using the  BSD 3-Clause License
  *
  * See LICENSE for license details.
@@ -301,12 +301,14 @@ namespace vcd_tracer {
             else {
                 T mask = static_cast<T>(1) << (bit_size - 1);
                 bool prev_bit = (value & mask) != 0;
-                bool compress = true;
+                // Only compress leading 0s; per IEEE 1364, VCD viewers
+                // zero-fill shorter values, so leading 1s must be kept.
+                bool compress = !prev_bit;
                 for (int i = bit_size - 2; i >= 0; i--) {
                     mask = mask >> 1;
                     const bool this_bit = (value & mask) != 0;
                     if (compress && (this_bit == prev_bit)) {
-                        // Compress the left bits until a change is present..
+                        // Compress leading zeros..
                     }
                     else {
                         compress = false;

--- a/src/vcd_tracer.hpp
+++ b/src/vcd_tracer.hpp
@@ -1,11 +1,11 @@
-/* 
+/*
  *  C++ VCD Tracer Library
  *
  *  For more information see https://github.com/nakane1chome/cpp-vcd-tracer
  *
  * Copyright (c) 2022, Philip Mulholland
  * All rights reserved.
- * 
+ *
  * Using the  BSD 3-Clause License
  *
  * See LICENSE for license details.
@@ -38,6 +38,19 @@ namespace vcd_tracer {
 
     /** Set this to true to log to stderr */
     constexpr bool SIMPLE_VCD_DEBUG = false;
+
+    /** Sanitize a name for use in VCD scope/variable declarations.
+        Replaces characters that are not alphanumeric or underscore with '_'.
+    */
+    inline std::string sanitize_vcd_name(std::string_view name) {
+        std::string result(name);
+        for (auto &c : result) {
+            if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
+                c = '_';
+            }
+        }
+        return result;
+    }
 
     /** A class to generate VCD a sequence of unique variable identifiers.
         The identifier is composed of printable ASCII characters from ! to ~ (decimal 33 to 126).
@@ -306,7 +319,7 @@ namespace vcd_tracer {
             @param dumper_fn The specialized function that can be used to dump this value to file.
         */
         value_base(const unsigned int bit_size,
-                   const char *var_type, 
+                   const char *var_type,
                    scope_fn::add_fn add_fn,
                    const std::string_view var_name,
                    scope_fn::dumper_fn dumper_fn)
@@ -347,9 +360,9 @@ namespace vcd_tracer {
       protected:
         // A common dumper function.
         template<typename T>
-        void dump(std::ostream &out, 
-                  const size_t bit_size, 
-                  const value_state state, 
+        void dump(std::ostream &out,
+                  const size_t bit_size,
+                  const value_state state,
                   const T value) const;
     };// value_base
 
@@ -357,11 +370,11 @@ namespace vcd_tracer {
     /** A helper function to determine if a change is traced.
         @retval true The sample has changed.
     */
-    template<typename T> 
+    template<typename T>
     inline bool sample_changed(const T new_sample, const T prev_sample) {
         return new_sample != prev_sample;
     }
-    
+
     /** Typed value for tracing representation.
         @tparam BIT_SIZE - The size in bits of the type.
         @tparam TRACE_DEPTH - When set to more than one a buffer of values can be accumulated before writing to file.
@@ -558,7 +571,7 @@ namespace vcd_tracer {
         module(scope_fn::register_fn register_fn,
                std::string_view instance_name) :_register_fn{ register_fn },
             _context{ std::make_shared<module_instance>(instance_name) } {
-            _context->vcd_scope << "$scope module " << instance_name << " $end\n";
+            _context->vcd_scope << "$scope module " << sanitize_vcd_name(instance_name) << " $end\n";
         }
         /** Declare a module instance, and provide the parent scope a reference to another module.
             @param parent   Provide the scope via this reference.
@@ -567,7 +580,7 @@ namespace vcd_tracer {
         module(module &parent,
                std::string_view instance_name) :_register_fn{ parent.get_register_fn() },
             _context{ std::make_shared<module_instance>(instance_name) } {
-            _context->vcd_scope << "$scope module " << instance_name << " $end\n";
+            _context->vcd_scope << "$scope module " << sanitize_vcd_name(instance_name) << " $end\n";
             parent._context->children.push_back(_context);
         }
 
@@ -581,7 +594,7 @@ namespace vcd_tracer {
                std::string_view instance_name,
                std::weak_ptr<module_instance> parent_context) :_register_fn{ register_fn },
             _context{ std::make_shared<module_instance>(instance_name) } {
-            _context->vcd_scope << "$scope module " << instance_name << " $end\n";
+            _context->vcd_scope << "$scope module " << sanitize_vcd_name(instance_name) << " $end\n";
             if (auto use_parent_context = parent_context.lock()) {
                 use_parent_context->children.push_back(_context);
             }
@@ -646,7 +659,7 @@ namespace vcd_tracer {
                 << "$var " << var_type
                 << " " << bit_size
                 << " " << value_context.identifier
-                << " " << var_name
+                << " " << sanitize_vcd_name(var_name)
                 << " $end\n";
             return value_context;
         }
@@ -739,7 +752,7 @@ namespace vcd_tracer {
         // Mapping of registers to identifiers and functions
         std::shared_ptr<map_data> _var_map = std::make_shared<map_data>();
 
-      public : 
+      public :
         //! The root module in the design hiearchy
         module root;
 

--- a/src/vcd_tracer.hpp
+++ b/src/vcd_tracer.hpp
@@ -41,6 +41,7 @@ namespace vcd_tracer {
 
     /** Sanitize a name for use in VCD scope/variable declarations.
         Replaces characters that are not alphanumeric or underscore with '_'.
+        Prepends '_' if the name starts with a digit.
     */
     inline std::string sanitize_vcd_name(std::string_view name) {
         std::string result(name);
@@ -48,6 +49,9 @@ namespace vcd_tracer {
             if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
                 c = '_';
             }
+        }
+        if (!result.empty() && std::isdigit(static_cast<unsigned char>(result[0]))) {
+            result.insert(result.begin(), '_');
         }
         return result;
     }

--- a/src/vcd_tracer.ipp
+++ b/src/vcd_tracer.ipp
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2022, Philip Mulholland
  * All rights reserved.
- * 
+ *
  * Using the  BSD 3-Clause License
  *
  * See LICENSE for license details.
@@ -47,7 +47,9 @@ namespace vcd_tracer {
                 }
                 else {
                     // Return the valid identifier.
+                    // Skip '#' and '$' as they are reserved in VCD.
                     _identifier[i]++;
+                    if (_identifier[i] == '#') _identifier[i] = '%';
                     return _identifier.data();
                 }
             } while (i != 0);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,3 +61,20 @@ catch_discover_tests(
   "relaxed_constexpr."
   OUTPUT_SUFFIX
   .xml)
+
+# --- Interoperability test ---
+add_executable(interop interop.cpp)
+target_link_libraries(interop PRIVATE project_options vcd_tracer)
+
+find_package(Python3 COMPONENTS Interpreter)
+if(Python3_FOUND)
+  add_test(
+    NAME interop_pytest
+    COMMAND ${Python3_EXECUTABLE} -m pytest
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_interop.py -v
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  set_tests_properties(interop_pytest PROPERTIES
+    ENVIRONMENT "INTEROP_EXE=$<TARGET_FILE:interop>"
+  )
+endif()

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,54 @@
+# Tests
+
+All tests are registered with CTest and can be run with `ctest` from the build directory.
+
+## Unit Tests
+
+### tests.cpp
+
+Catch2 unit tests for the VCD tracer library. Covers:
+
+- **VCD identifier generation** — verifies the printable ASCII sequence, including correct skipping of reserved `#` and `$` characters.
+- **Integer value formatting** — binary encoding of integer values to VCD output.
+- **Trace buffer** — buffered value change detection and sequence tracking.
+- **Module hierarchy** — scope creation and variable registration.
+- **Module elaboration** — deferred signal binding via `elaborate()`.
+- **Top-level tracing** — full VCD header generation and time-based value dumps.
+- **GitHub Issue #5** — regression test for leading-ones compression bug.
+
+### constexpr_tests.cpp
+
+Compile-time (`constexpr`) tests for the VCD identifier generator. Validates that identifier generation is fully constexpr-evaluable at keys 0, 87, 88, and 176 — covering single-character, boundary, and multi-character identifiers.
+
+Also compiled as `relaxed_constexpr_tests` with `CATCH_CONFIG_RUNTIME_STATIC_REQUIRE` to allow debugging constexpr failures at runtime.
+
+## Interoperability Tests
+
+### interop.cpp
+
+C++ program that generates a VCD file and a reference CSV simultaneously. Uses a `data_cycle` template to cycle signals through test values, covering:
+
+- **Signal types**: bool, float, double, and unsigned integers at widths 1, 2, 4, 7, 8, 9, 15, 16, 17, 24, 31, 32, 33, and 64 bits.
+- **Pathological values**: `FLT_MIN/MAX`, `DBL_MIN/MAX`, `DBL_EPSILON`, alternating bit patterns (`0x55`, `0xAA`, `0x5A`) at all integer widths.
+- **Hierarchy corner cases**: empty module, pass-through module (only sub-scopes), single-char name, digit-starting name (sanitized to `_1st`), special characters (sanitized), duplicate module names at different levels, 8-level deep nesting, module with same name as a signal.
+
+### test_interop.py
+
+Pytest harness with three tests, all using `interop.cpp` output:
+
+- **test_interop** — Converts VCD to CSV using pyvcd (`vcd_to_csv.py`) and compares against the C++ reference CSV. Uses `pytest.approx` for float tolerance.
+- **test_interop_gtkwave** — Exports VCD to CSV using GTKWave's TCL scripting (`gtkwave_export.tcl`) and compares against the C++ reference CSV. Skips if GTKWave is not installed.
+- **test_interop_gtkwave_screenshot** — Captures a GTKWave screenshot of the VCD waveforms under `xvfb-run`. Skips if GTKWave, xwd, or xvfb-run are not available.
+
+All three tests save artifacts (VCD, CSV files, screenshot) to `build/artifacts/` by default, or to the path specified by the `INTEROP_ARTIFACTS` environment variable.
+
+### Supporting Files
+
+| File | Purpose |
+|------|---------|
+| `vcd_to_csv.py` | Converts VCD files to CSV using pyvcd. Handles scalar, vector, and real signal types. |
+| `gtkwave_export.tcl` | GTKWave TCL batch script that exports all signals to CSV via marker-based value queries. |
+| `gtkwave_screenshot.tcl` | GTKWave TCL batch script that captures a screenshot via `xwd` and converts to PNG. |
+| `requirements.txt` | Python dependencies: `pyvcd` and `pytest`. |
+| `catch_main.cpp` | Shared Catch2 `main()` entry point for unit tests. |
+| `CMakeLists.txt` | Build and test registration for all C++ targets and the pytest suite. |

--- a/test/constexpr_tests.cpp
+++ b/test/constexpr_tests.cpp
@@ -1,11 +1,11 @@
-/*  
+/*
  *  C++ VCD Tracer Library Tests
  *
  *  For more information see https://github.com/nakane1chome/cpp-vcd-tracer
  *
  * Copyright (c) 2022, Philip Mulholland
  * All rights reserved.
- * 
+ *
  * Using the  BSD 3-Clause License
  *
  * See LICENSE for license details.
@@ -36,14 +36,14 @@ TEST_CASE("VCD identifiers are created-0 char", "[GenerateVcdKey-0]") {
     STATIC_REQUIRE(std::string_view(GenerateVcdKey(0).data()) == "!");
 }
 
-TEST_CASE("VCD identifiers are created-89 char", "[GenerateVcdKey-89]") {
-    STATIC_REQUIRE(std::string_view(GenerateVcdKey(89).data()) == "z");
+TEST_CASE("VCD identifiers are created-87 char", "[GenerateVcdKey-87]") {
+    STATIC_REQUIRE(std::string_view(GenerateVcdKey(87).data()) == "z");
 }
 
-TEST_CASE("VCD identifiers are created-90 char", "[GenerateVcdKey-90]") {
-    STATIC_REQUIRE(std::string_view(GenerateVcdKey(90).data()) == "!!");
+TEST_CASE("VCD identifiers are created-88 char", "[GenerateVcdKey-88]") {
+    STATIC_REQUIRE(std::string_view(GenerateVcdKey(88).data()) == "!!");
 }
 
-TEST_CASE("VCD identifiers are created-180 char", "[GenerateVcdKey-180]") {
-    STATIC_REQUIRE(std::string_view(GenerateVcdKey(180).data()) == "\"!");
+TEST_CASE("VCD identifiers are created-176 char", "[GenerateVcdKey-176]") {
+    STATIC_REQUIRE(std::string_view(GenerateVcdKey(176).data()) == "\"!");
 }

--- a/test/gtkwave_export.tcl
+++ b/test/gtkwave_export.tcl
@@ -1,0 +1,100 @@
+# GTKWave batch export script: reads loaded VCD and writes CSV
+# Usage: gtkwave input.vcd -S gtkwave_export.tcl
+# Set GTKWAVE_CSV_OUT environment variable to specify output path.
+
+set csv_out $::env(GTKWAVE_CSV_OUT)
+
+set num_facs [gtkwave::getNumFacs]
+set max_time [gtkwave::getMaxTime]
+
+# Enumerate all signals and add to viewer
+set all_signals {}
+for {set i 0} {$i < $num_facs} {incr i} {
+    lappend all_signals [gtkwave::getFacName $i]
+}
+gtkwave::addSignalsFromList $all_signals
+
+# Build signal info: leaf name, bit width (0 for non-vectors)
+set leaf_names {}
+set bit_widths {}
+foreach sig $all_signals {
+    # Extract leaf name and bit width from "root.l0.u9[8:0]"
+    set leaf $sig
+    set bits 0
+    set bracket [string first "\[" $leaf]
+    if {$bracket >= 0} {
+        # Parse bit range [MSB:LSB] to get width
+        set range [string range $leaf [expr {$bracket + 1}] end-1]
+        set parts [split $range ":"]
+        set msb [lindex $parts 0]
+        set lsb [lindex $parts 1]
+        set bits [expr {$msb - $lsb + 1}]
+        set leaf [string range $leaf 0 [expr {$bracket - 1}]]
+    }
+    # Take last component after "."
+    set dot [string last "." $leaf]
+    if {$dot >= 0} {
+        set leaf [string range $leaf [expr {$dot + 1}] end]
+    }
+    lappend leaf_names $leaf
+    lappend bit_widths $bits
+}
+
+# Sort by leaf name, keeping parallel arrays in sync
+set indices {}
+for {set i 0} {$i < [llength $leaf_names]} {incr i} {
+    lappend indices $i
+}
+set sorted_indices [lsort -command {apply {{a b} {
+    set na [lindex $::leaf_names $a]
+    set nb [lindex $::leaf_names $b]
+    return [string compare $na $nb]
+}}} $indices]
+
+# Convert a value string to unsigned decimal.
+# GTKWave may return hex or binary depending on bit width.
+# Heuristic: if string length == bit width and all chars are 0/1, it's binary.
+proc to_decimal {val bits} {
+    if {$bits == 0} {
+        # Scalar or real — return as-is
+        return $val
+    }
+    set len [string length $val]
+    if {$len == $bits && [regexp {^[01]+$} $val]} {
+        # Binary representation
+        set result 0
+        foreach bit [split $val ""] {
+            set result [expr {$result * 2 + $bit}]
+        }
+        return $result
+    }
+    # Hex representation
+    scan $val %llx result
+    return $result
+}
+
+# Write CSV
+set fp [open $csv_out w]
+
+# Header
+puts -nonewline $fp "time"
+foreach idx $sorted_indices {
+    puts -nonewline $fp ",[lindex $leaf_names $idx]"
+}
+puts $fp ""
+
+# Data rows: time 1 to max_time
+for {set t 1} {$t <= $max_time} {incr t} {
+    gtkwave::setMarker $t
+    puts -nonewline $fp $t
+    foreach idx $sorted_indices {
+        set sig [lindex $all_signals $idx]
+        set bits [lindex $bit_widths $idx]
+        set val [gtkwave::getTraceValueAtMarkerFromName $sig]
+        puts -nonewline $fp ",[to_decimal $val $bits]"
+    }
+    puts $fp ""
+}
+
+close $fp
+gtkwave::/File/Quit

--- a/test/gtkwave_screenshot.tcl
+++ b/test/gtkwave_screenshot.tcl
@@ -1,0 +1,37 @@
+# GTKWave batch screenshot script: loads VCD, adds all signals, saves screenshot.
+# Usage: [xvfb-run] gtkwave input.vcd -S gtkwave_screenshot.tcl
+# Set GTKWAVE_PNG_OUT environment variable to specify output path.
+# Requires: xwd on PATH, ffmpeg or python3+Pillow for PNG conversion.
+
+set png_out $::env(GTKWAVE_PNG_OUT)
+set xwd_tmp "${png_out}.xwd"
+
+# Add all signals
+set num_facs [gtkwave::getNumFacs]
+set all_signals {}
+for {set i 0} {$i < $num_facs} {incr i} {
+    lappend all_signals [gtkwave::getFacName $i]
+}
+gtkwave::addSignalsFromList $all_signals
+gtkwave::/Time/Zoom/Zoom_Best_Fit
+gtkwave::/Edit/Sort/Alphabetize_All
+
+# Allow rendering to complete, then capture and quit
+after 1000 {
+    # Capture root window (under xvfb-run this is just the GTKWave window)
+    exec xwd -root -screen -out $::xwd_tmp
+
+    # Convert XWD to PNG
+    if {![catch {exec ffmpeg -y -i $::xwd_tmp $::png_out} err]} {
+        file delete $::xwd_tmp
+    } elseif {![catch {exec python3 -c "
+from PIL import Image
+img = Image.open('$::xwd_tmp')
+img.save('$::png_out')
+" } err]} {
+        file delete $::xwd_tmp
+    }
+    # If both fail, leave the XWD file
+
+    gtkwave::/File/Quit
+}

--- a/test/interop.cpp
+++ b/test/interop.cpp
@@ -14,7 +14,9 @@
 #include "../src/vcd_tracer.hpp"
 #include <algorithm>
 #include <array>
+#include <cfloat>
 #include <cmath>
+#include <climits>
 #include <string>
 #include <fstream>
 
@@ -67,11 +69,18 @@ struct data_cycle : data_cycle_base {
   void write_csv(std::ostream &csv_out) override {
     // Write the current value (index was already advanced)
     size_t cur = (index == 0) ? N - 1 : index - 1;
-    csv_out << +data[cur];
+    if constexpr (std::is_floating_point_v<DATA_T>) {
+      // Match the VCD library's %-.16g precision
+      char buf[32];
+      std::snprintf(buf, sizeof(buf), "%-.16g", static_cast<double>(data[cur]));
+      csv_out << buf;
+    } else {
+      csv_out << +data[cur];
+    }
   }
 };
 
-static constexpr unsigned int CYCLES = 20;
+static constexpr unsigned int CYCLES = 40;
 static constexpr unsigned int TICK_NS = 1;
 
 int main(int argc, const char **argv) {
@@ -91,22 +100,91 @@ int main(int argc, const char **argv) {
     vcd_tracer::module l0_l0_l0(l0_l0, "l0-l0-l0");
     vcd_tracer::module l0_l0_l0_l0(l0_l0_l0, "l0-l0-l0-l0");
 
+    // Corner case: empty module (no signals, no children)
+    vcd_tracer::module empty(dumper.root, "empty");
+
+    // Corner case: pass-through module (only sub-scopes, no direct signals)
+    vcd_tracer::module passthru(dumper.root, "passthru");
+    vcd_tracer::module passthru_inner(passthru, "inner");
+
+    // Corner case: single-char module name
+    vcd_tracer::module m_a(dumper.root, "a");
+
+    // Corner case: name starting with digit (sanitizer should handle)
+    vcd_tracer::module m_1st(dumper.root, "1st");
+
+    // Corner case: name with multiple special chars (tests sanitizer)
+    vcd_tracer::module m_special(dumper.root, "foo.bar@baz");
+
+    // Corner case: duplicate module names at different levels
+    vcd_tracer::module dup_a(dumper.root, "dup");
+    vcd_tracer::module dup_b(l0, "dup");
+
+    // Corner case: deep nesting (8 levels below root)
+    vcd_tracer::module deep1(dumper.root, "d1");
+    vcd_tracer::module deep2(deep1, "d2");
+    vcd_tracer::module deep3(deep2, "d3");
+    vcd_tracer::module deep4(deep3, "d4");
+    vcd_tracer::module deep5(deep4, "d5");
+    vcd_tracer::module deep6(deep5, "d6");
+    vcd_tracer::module deep7(deep6, "d7");
+    vcd_tracer::module deep8(deep7, "d8");
+
     data_cycle<vcd_tracer::value<bool>, bool, 2> b1{l0, "b1", false, true};
-    data_cycle<vcd_tracer::value<double>, double, 4> dbl{l1, "dbl", 0.0, 1.5, -3.25, 100.0};
-    data_cycle<vcd_tracer::value<float>, float, 3> flt{l0_l0, "flt", 0.0f, 2.5f, -1.0f};
+
+    // Signals in corner-case modules
+    data_cycle<vcd_tracer::value<uint8_t>, uint8_t, 3> pt_sig{passthru_inner, "pt_sig",
+        0x00, 0xAA, 0x55};
+    data_cycle<vcd_tracer::value<uint8_t, 4>, uint8_t, 2> a_sig{m_a, "a_sig", 0x3, 0xC};
+    data_cycle<vcd_tracer::value<uint16_t>, uint16_t, 2> dig_sig{m_1st, "dig_sig",
+        0x1234, 0xABCD};
+    data_cycle<vcd_tracer::value<uint8_t>, uint8_t, 2> spc_sig{m_special, "spc_sig",
+        0x5A, 0xA5};
+    data_cycle<vcd_tracer::value<uint8_t>, uint8_t, 3> dup_r{dup_a, "dup_r", 0x11, 0x22, 0x33};
+    data_cycle<vcd_tracer::value<uint8_t>, uint8_t, 3> dup_l{dup_b, "dup_l", 0x44, 0x55, 0x66};
+    data_cycle<vcd_tracer::value<uint32_t>, uint32_t, 4> deep_sig{deep8, "deep_sig",
+        0xDEADBEEFu, 0xCAFEBABEu, 0x12345678u, 0x5A5A5A5Au};
+
+    // Corner case: module same name as a signal (module "u8" alongside signal "u8")
+    vcd_tracer::module m_u8(dumper.root, "u8");
+    data_cycle<vcd_tracer::value<uint8_t>, uint8_t, 2> u8m_sig{m_u8, "u8m_sig", 0xDE, 0xAD};
+    data_cycle<vcd_tracer::value<double>, double, 8> dbl{l1, "dbl",
+        0.0, 1.5, -3.25, 100.0,
+        DBL_MIN, DBL_MAX, -DBL_MAX, DBL_EPSILON};
+    data_cycle<vcd_tracer::value<float>, float, 7> flt{l0_l0, "flt",
+        0.0f, 2.5f, -1.0f,
+        FLT_MIN, FLT_MAX, -FLT_MAX, FLT_EPSILON};
     data_cycle<vcd_tracer::value<uint8_t, 1>, uint8_t, 2> u1{l0_l1, "u1", 0x0, 0x1};
     data_cycle<vcd_tracer::value<uint8_t, 2>, uint8_t, 4> u2{l1_l0, "u2", 0x0, 0x1, 0x2, 0x3};
-    data_cycle<vcd_tracer::value<uint8_t, 4>, uint8_t, 4> u4{l0_l0_l0, "u4", 0x0, 0x5, 0xA, 0xF};
-    data_cycle<vcd_tracer::value<uint8_t>, uint8_t, 3> u8{l0, "u8", 0x00, 0x7F, 0xFF};
-    data_cycle<vcd_tracer::value<uint16_t, 9>, uint16_t, 3> u9{l0, "u9", 0x000, 0x100, 0x1FF};
-    data_cycle<vcd_tracer::value<uint16_t, 15>, uint16_t, 3> u15{l0, "u15", 0x0000, 0x3FFF, 0x7FFF};
-    data_cycle<vcd_tracer::value<uint16_t>, uint16_t, 3> u16{l0, "u16", 0x0000, 0x8000, 0xFFFF};
-    data_cycle<vcd_tracer::value<uint32_t, 17>, uint32_t, 3> u17{l0, "u17", 0x00000, 0x10000, 0x1FFFF};
-    data_cycle<vcd_tracer::value<uint32_t, 24>, uint32_t, 3> u24{l0_l0_l0_l0, "u24", 0x000000, 0x7FFFFF, 0xFFFFFF};
-    data_cycle<vcd_tracer::value<uint32_t, 31>, uint32_t, 3> u31{l0, "u31", 0x00000000, 0x3FFFFFFF, 0x7FFFFFFF};
-    data_cycle<vcd_tracer::value<uint32_t>, uint32_t, 3> u32{l0, "u32", 0x00000000u, 0x80000000u, 0xFFFFFFFFu};
-    data_cycle<vcd_tracer::value<uint64_t, 33>, uint64_t, 3> u33{l0, "u33", 0x0ull, 0x100000000ull, 0x1FFFFFFFFull};
-    data_cycle<vcd_tracer::value<uint64_t>, uint64_t, 3> u64{l0, "u64", 0x0ull, 0x7FFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull};
+    data_cycle<vcd_tracer::value<uint8_t, 4>, uint8_t, 6> u4{l0_l0_l0, "u4",
+        0x0, 0x5, 0xA, 0xF, 0x5, 0xA};
+    data_cycle<vcd_tracer::value<uint8_t, 7>, uint8_t, 6> u7{l0, "u7",
+        0x00, 0x7F, 0x01, 0x55, 0x2A, 0x5A};
+    data_cycle<vcd_tracer::value<uint8_t>, uint8_t, 7> u8{l0, "u8",
+        0x00, 0x7F, 0xFF, 0x01, 0x55, 0xAA, 0x5A};
+    data_cycle<vcd_tracer::value<uint16_t, 9>, uint16_t, 6> u9{l0, "u9",
+        0x000, 0x100, 0x1FF, 0x155, 0x0AA, 0x15A};
+    data_cycle<vcd_tracer::value<uint16_t, 15>, uint16_t, 6> u15{l0, "u15",
+        0x0000, 0x3FFF, 0x7FFF, 0x5555, 0x2AAA, 0x5A5A};
+    data_cycle<vcd_tracer::value<uint16_t>, uint16_t, 7> u16{l0, "u16",
+        0x0000, 0x8000, 0xFFFF, 0x0001, 0x5555, 0xAAAA, 0x5A5A};
+    data_cycle<vcd_tracer::value<uint32_t, 17>, uint32_t, 6> u17{l0, "u17",
+        0x00000, 0x10000, 0x1FFFF, 0x15555, 0x0AAAA, 0x15A5A};
+    data_cycle<vcd_tracer::value<uint32_t, 24>, uint32_t, 6> u24{l0_l0_l0_l0, "u24",
+        0x000000, 0x7FFFFF, 0xFFFFFF, 0x555555, 0xAAAAAA, 0x5A5A5A};
+    data_cycle<vcd_tracer::value<uint32_t, 31>, uint32_t, 7> u31{l0, "u31",
+        0x00000000, 0x3FFFFFFF, 0x7FFFFFFF, 0x00000001,
+        0x55555555, 0x2AAAAAAA, 0x5A5A5A5A};
+    data_cycle<vcd_tracer::value<uint32_t>, uint32_t, 7> u32{l0, "u32",
+        0x00000000u, 0x80000000u, 0xFFFFFFFFu, 0x00000001u,
+        0x55555555u, 0xAAAAAAAAu, 0x5A5A5A5Au};
+    data_cycle<vcd_tracer::value<uint64_t, 33>, uint64_t, 7> u33{l0, "u33",
+        0x0ull, 0x100000000ull, 0x1FFFFFFFFull, 0x1ull,
+        0x155555555ull, 0x0AAAAAAAAull, 0x15A5A5A5Aull};
+    data_cycle<vcd_tracer::value<uint64_t>, uint64_t, 8> u64{l0, "u64",
+        0x0ull, 0x7FFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull,
+        0x1ull, 0x8000000000000000ull,
+        0x5555555555555555ull, 0xAAAAAAAAAAAAAAAAull, 0x5A5A5A5A5A5A5A5Aull};
 
     // Open files for output
     {

--- a/test/interop.cpp
+++ b/test/interop.cpp
@@ -1,0 +1,182 @@
+/*
+ *  C++ VCD Tracer Library Interoperability test
+ *
+ *  For more information see https://github.com/nakane1chome/cpp-vcd-tracer
+ *
+ * Copyright (c) 2026, Philip Mulholland
+ * All rights reserved.
+ *
+ * Using the  BSD 3-Clause License
+ *
+ * See LICENSE for license details.
+ */
+
+#include "../src/vcd_tracer.hpp"
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+#include <fstream>
+
+/** Generic data cycling base class */
+class data_cycle_base {
+protected:
+  data_cycle_base() {
+    generators.emplace_back(this);
+  }
+public:
+  virtual void hdr(std::ostream &csv_out) = 0;
+  virtual void advance() = 0;
+  virtual void write_csv(std::ostream &csv_out) = 0;
+  virtual const std::string &get_name() const = 0;
+  static std::vector<data_cycle_base *> generators;
+};
+
+std::vector<data_cycle_base *> data_cycle_base::generators;
+
+/** Type specialized data cycling base class */
+template<typename TRACE_T, typename DATA_T, size_t N>
+struct data_cycle : data_cycle_base {
+  template<typename... Args>
+  data_cycle(vcd_tracer::module &parent, std::string_view var_name, Args&&... args)
+  : data_cycle_base()
+  , data{{static_cast<DATA_T>(args)...}}
+  , name(var_name)
+  {
+    parent.elaborate(var, var_name);
+  }
+  std::array<DATA_T, N> data;
+  TRACE_T var;
+  size_t index{0};
+  std::string name;
+
+  void hdr(std::ostream &csv_out) override {
+    csv_out << name;
+  }
+
+  const std::string &get_name() const override {
+    return name;
+  }
+
+  void advance() override {
+    DATA_T v = data[index++];
+    index = index % N;
+    var.set(v);
+  }
+
+  void write_csv(std::ostream &csv_out) override {
+    // Write the current value (index was already advanced)
+    size_t cur = (index == 0) ? N - 1 : index - 1;
+    csv_out << +data[cur];
+  }
+};
+
+static constexpr unsigned int CYCLES = 20;
+static constexpr unsigned int TICK_NS = 1;
+
+int main(int argc, const char **argv) {
+
+    const std::string vcd_fout_name{ (argc > 1) ? argv[1] : "interop.vcd" };
+    const std::string csv_fout_name{ (argc > 2) ? argv[2] : "interop.csv" };
+
+    // The top module defines the base of the signal hierarchy
+    vcd_tracer::top dumper("root");
+
+    // Create module hierarchy
+    vcd_tracer::module l0(dumper.root, "l0");
+    vcd_tracer::module l0_l0(l0, "l0-l0");
+    vcd_tracer::module l0_l1(l0, "l0-l1");
+    vcd_tracer::module l1(dumper.root, "l1");
+    vcd_tracer::module l1_l0(l1, "l1-l0");
+    vcd_tracer::module l0_l0_l0(l0_l0, "l0-l0-l0");
+    vcd_tracer::module l0_l0_l0_l0(l0_l0_l0, "l0-l0-l0-l0");
+
+    data_cycle<vcd_tracer::value<bool>, bool, 2> b1{l0, "b1", false, true};
+    data_cycle<vcd_tracer::value<double>, double, 4> dbl{l1, "dbl", 0.0, 1.5, -3.25, 100.0};
+    data_cycle<vcd_tracer::value<float>, float, 3> flt{l0_l0, "flt", 0.0f, 2.5f, -1.0f};
+    data_cycle<vcd_tracer::value<uint8_t, 1>, uint8_t, 2> u1{l0_l1, "u1", 0x0, 0x1};
+    data_cycle<vcd_tracer::value<uint8_t, 2>, uint8_t, 4> u2{l1_l0, "u2", 0x0, 0x1, 0x2, 0x3};
+    data_cycle<vcd_tracer::value<uint8_t, 4>, uint8_t, 4> u4{l0_l0_l0, "u4", 0x0, 0x5, 0xA, 0xF};
+    data_cycle<vcd_tracer::value<uint8_t>, uint8_t, 3> u8{l0, "u8", 0x00, 0x7F, 0xFF};
+    data_cycle<vcd_tracer::value<uint16_t, 9>, uint16_t, 3> u9{l0, "u9", 0x000, 0x100, 0x1FF};
+    data_cycle<vcd_tracer::value<uint16_t, 15>, uint16_t, 3> u15{l0, "u15", 0x0000, 0x3FFF, 0x7FFF};
+    data_cycle<vcd_tracer::value<uint16_t>, uint16_t, 3> u16{l0, "u16", 0x0000, 0x8000, 0xFFFF};
+    data_cycle<vcd_tracer::value<uint32_t, 17>, uint32_t, 3> u17{l0, "u17", 0x00000, 0x10000, 0x1FFFF};
+    data_cycle<vcd_tracer::value<uint32_t, 24>, uint32_t, 3> u24{l0_l0_l0_l0, "u24", 0x000000, 0x7FFFFF, 0xFFFFFF};
+    data_cycle<vcd_tracer::value<uint32_t, 31>, uint32_t, 3> u31{l0, "u31", 0x00000000, 0x3FFFFFFF, 0x7FFFFFFF};
+    data_cycle<vcd_tracer::value<uint32_t>, uint32_t, 3> u32{l0, "u32", 0x00000000u, 0x80000000u, 0xFFFFFFFFu};
+    data_cycle<vcd_tracer::value<uint64_t, 33>, uint64_t, 3> u33{l0, "u33", 0x0ull, 0x100000000ull, 0x1FFFFFFFFull};
+    data_cycle<vcd_tracer::value<uint64_t>, uint64_t, 3> u64{l0, "u64", 0x0ull, 0x7FFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull};
+
+    // Open files for output
+    {
+        std::ofstream vcd_fout(vcd_fout_name);
+        std::ofstream csv_fout(csv_fout_name);
+
+        // Finalize signals before tracing
+        // The VCD format does not allow dynamic signal definition.
+        dumper.finalize_header(vcd_fout,
+                               std::chrono::system_clock::from_time_t(0));
+
+        // Sort generators by name to match pyvcd's alphabetical column order
+        auto sorted = data_cycle_base::generators;
+        std::sort(sorted.begin(), sorted.end(),
+                  [](const data_cycle_base *a, const data_cycle_base *b) {
+                      return a->get_name() < b->get_name();
+                  });
+
+        csv_fout << "time";
+        for (auto *g : sorted) {
+          csv_fout << ",";
+          g->hdr(csv_fout);
+        }
+        csv_fout << "\n";
+
+        // time_update_abs(i) first dumps pending changes at the
+        // current tracepoint, then advances tracepoint to i.
+        // So values set before time_update_abs(i) appear at
+        // time i-1 in the VCD.
+        //
+        // vcd_to_csv skips time 0 and records state when the
+        // next timestamp appears.
+        //
+        // Strategy: advance, then call time_update_abs(i+1).
+        // The advance values get dumped at time i.
+        // Write CSV for time i with those same values.
+        // First call at i=0 dumps at time 0 (skipped by vcd_to_csv).
+
+        for (unsigned int i = 0; i < CYCLES; i++) {
+
+          // Set signals for this timestep
+          for (auto *g : data_cycle_base::generators) {
+            g->advance();
+          }
+
+          // Dump to VCD — values appear at tracepoint i
+          dumper.time_update_abs(vcd_fout, std::chrono::nanoseconds{ TICK_NS * (i + 1) });
+
+          // Write CSV (skip time 0 to match vcd_to_csv behavior)
+          if (i > 0) {
+            csv_fout << i;
+            for (auto *g : sorted) {
+              csv_fout << ",";
+              g->write_csv(csv_fout);
+            }
+            csv_fout << "\n";
+          }
+
+        }
+
+        // vcd_to_csv appends a final row for the last timestamp
+        // with accumulated state. Write matching row.
+        csv_fout << CYCLES;
+        for (auto *g : sorted) {
+          csv_fout << ",";
+          g->write_csv(csv_fout);
+        }
+        csv_fout << "\n";
+
+    }
+
+    return 0;
+}

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,2 @@
+pyvcd
+pytest

--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -1,0 +1,69 @@
+import subprocess
+import csv
+import os
+import pytest
+from vcd_to_csv import vcd_to_csv
+
+
+def get_interop_exe():
+    exe = os.environ.get("INTEROP_EXE")
+    if not exe:
+        pytest.skip("INTEROP_EXE not set")
+    return exe
+
+
+def parse_csv(path):
+    with open(path) as f:
+        return list(csv.reader(f))
+
+
+def values_equal(a, b):
+    """Compare two CSV cell values, using numeric comparison for floats."""
+    if a == b:
+        return True
+    try:
+        return float(a) == pytest.approx(float(b), rel=1e-9)
+    except (ValueError, TypeError):
+        return False
+
+
+def test_interop(tmp_path):
+    exe = get_interop_exe()
+
+    vcd_path = str(tmp_path / "interop.vcd")
+    cpp_csv_path = str(tmp_path / "cpp_output.csv")
+    py_csv_path = str(tmp_path / "py_output.csv")
+
+    # Run the C++ interop executable to produce VCD and reference CSV
+    result = subprocess.run(
+        [exe, vcd_path, cpp_csv_path],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"interop failed: {result.stderr}"
+
+    # Convert VCD to CSV using pyvcd
+    vcd_to_csv(vcd_path, py_csv_path)
+
+    cpp_rows = parse_csv(cpp_csv_path)
+    py_rows = parse_csv(py_csv_path)
+
+    # Compare headers
+    assert cpp_rows[0] == py_rows[0], (
+        f"Header mismatch:\n  C++:   {cpp_rows[0]}\n  pyvcd: {py_rows[0]}"
+    )
+
+    # Compare row count
+    assert len(cpp_rows) == len(py_rows), (
+        f"Row count mismatch: C++ has {len(cpp_rows)}, pyvcd has {len(py_rows)}"
+    )
+
+    # Compare data rows with numeric tolerance for floats
+    for i, (cpp_row, py_row) in enumerate(zip(cpp_rows[1:], py_rows[1:]), 1):
+        assert len(cpp_row) == len(py_row), (
+            f"Row {i}: column count mismatch"
+        )
+        for j, (c, p) in enumerate(zip(cpp_row, py_row)):
+            assert values_equal(c, p), (
+                f"Row {i}, col {j} ({cpp_rows[0][j]}): "
+                f"C++={c!r} != pyvcd={p!r}"
+            )

--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -175,7 +175,10 @@ def test_interop_gtkwave_screenshot(tmp_path):
     result = subprocess.run(
         ["xvfb-run", "--auto-servernum",
          "--server-args", "-screen 0 1920x1080x24",
-         "gtkwave", vcd_path, "-T", tcl_script],
+         "gtkwave", vcd_path,
+         "-4", "initial_window_x 1920",
+         "-4", "initial_window_y 1080",
+         "-T", tcl_script],
         capture_output=True, text=True, env=env, timeout=30
     )
     assert result.returncode == 0, f"gtkwave screenshot failed: {result.stderr}"

--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -13,6 +13,15 @@ def get_interop_exe():
     return exe
 
 
+def get_artifacts_dir():
+    exe = os.environ.get("INTEROP_EXE", "")
+    artifacts_dir = os.environ.get("INTEROP_ARTIFACTS")
+    if not artifacts_dir:
+        artifacts_dir = os.path.join(os.path.dirname(exe), "..", "artifacts")
+    os.makedirs(artifacts_dir, exist_ok=True)
+    return artifacts_dir
+
+
 def parse_csv(path):
     with open(path) as f:
         return list(csv.reader(f))
@@ -44,6 +53,12 @@ def test_interop(tmp_path):
 
     # Convert VCD to CSV using pyvcd
     vcd_to_csv(vcd_path, py_csv_path)
+
+    # Save artifacts
+    artifacts_dir = get_artifacts_dir()
+    shutil.copy2(vcd_path, os.path.join(artifacts_dir, "interop.vcd"))
+    shutil.copy2(cpp_csv_path, os.path.join(artifacts_dir, "interop.csv"))
+    shutil.copy2(py_csv_path, os.path.join(artifacts_dir, "pyvcd.csv"))
 
     cpp_rows = parse_csv(cpp_csv_path)
     py_rows = parse_csv(py_csv_path)
@@ -103,6 +118,10 @@ def test_interop_gtkwave(tmp_path):
     )
     assert result.returncode == 0, f"gtkwave failed: {result.stderr}"
 
+    # Save artifact
+    artifacts_dir = get_artifacts_dir()
+    shutil.copy2(gtk_csv_path, os.path.join(artifacts_dir, "gtkwave.csv"))
+
     # Compare CSVs
     cpp_rows = parse_csv(cpp_csv_path)
     gtk_rows = parse_csv(gtk_csv_path)
@@ -161,14 +180,8 @@ def test_interop_gtkwave_screenshot(tmp_path):
     )
     assert result.returncode == 0, f"gtkwave screenshot failed: {result.stderr}"
 
-    # Copy artifacts to INTEROP_ARTIFACTS dir, defaulting to build/artifacts/
-    artifacts_dir = os.environ.get("INTEROP_ARTIFACTS")
-    if not artifacts_dir:
-        # Default: build/artifacts/ relative to the built executable
-        artifacts_dir = os.path.join(os.path.dirname(exe), "..", "artifacts")
-    os.makedirs(artifacts_dir, exist_ok=True)
-    shutil.copy2(vcd_path, os.path.join(artifacts_dir, "interop.vcd"))
-    shutil.copy2(cpp_csv_path, os.path.join(artifacts_dir, "interop.csv"))
+    # Save screenshot artifact
+    artifacts_dir = get_artifacts_dir()
     if os.path.exists(png_path):
         shutil.copy2(png_path, os.path.join(artifacts_dir, "gtkwave_screenshot.png"))
 

--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -123,3 +123,54 @@ def test_interop_gtkwave(tmp_path):
                 f"Row {i}, col {j} ({cpp_rows[0][j]}): "
                 f"C++={c!r} != gtkwave={g!r}"
             )
+
+
+def test_interop_gtkwave_screenshot(tmp_path):
+    exe = get_interop_exe()
+
+    if not shutil.which("gtkwave"):
+        pytest.skip("gtkwave not found")
+    if not shutil.which("xwd"):
+        pytest.skip("xwd not found")
+
+    vcd_path = str(tmp_path / "interop.vcd")
+    cpp_csv_path = str(tmp_path / "cpp_output.csv")
+    png_path = str(tmp_path / "gtkwave_screenshot.png")
+
+    # Run the C++ interop executable to produce VCD and reference CSV
+    result = subprocess.run(
+        [exe, vcd_path, cpp_csv_path],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"interop failed: {result.stderr}"
+
+    # Run GTKWave with screenshot script under xvfb-run
+    tcl_script = os.path.join(os.path.dirname(__file__), "gtkwave_screenshot.tcl")
+    env = os.environ.copy()
+    env["GTKWAVE_PNG_OUT"] = png_path
+
+    # xvfb-run is required for clean screenshots (virtual framebuffer)
+    if not shutil.which("xvfb-run"):
+        pytest.skip("xvfb-run not found")
+
+    result = subprocess.run(
+        ["xvfb-run", "--auto-servernum",
+         "--server-args", "-screen 0 1920x1080x24",
+         "gtkwave", vcd_path, "-T", tcl_script],
+        capture_output=True, text=True, env=env, timeout=30
+    )
+    assert result.returncode == 0, f"gtkwave screenshot failed: {result.stderr}"
+
+    # Copy artifacts to INTEROP_ARTIFACTS dir, defaulting to build/artifacts/
+    artifacts_dir = os.environ.get("INTEROP_ARTIFACTS")
+    if not artifacts_dir:
+        # Default: build/artifacts/ relative to the built executable
+        artifacts_dir = os.path.join(os.path.dirname(exe), "..", "artifacts")
+    os.makedirs(artifacts_dir, exist_ok=True)
+    shutil.copy2(vcd_path, os.path.join(artifacts_dir, "interop.vcd"))
+    shutil.copy2(cpp_csv_path, os.path.join(artifacts_dir, "interop.csv"))
+    if os.path.exists(png_path):
+        shutil.copy2(png_path, os.path.join(artifacts_dir, "gtkwave_screenshot.png"))
+
+    assert os.path.exists(png_path), "Screenshot was not created"
+    assert os.path.getsize(png_path) > 0, "Screenshot file is empty"

--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -1,6 +1,7 @@
 import subprocess
 import csv
 import os
+import shutil
 import pytest
 from vcd_to_csv import vcd_to_csv
 
@@ -66,4 +67,59 @@ def test_interop(tmp_path):
             assert values_equal(c, p), (
                 f"Row {i}, col {j} ({cpp_rows[0][j]}): "
                 f"C++={c!r} != pyvcd={p!r}"
+            )
+
+
+def test_interop_gtkwave(tmp_path):
+    exe = get_interop_exe()
+
+    if not shutil.which("gtkwave"):
+        pytest.skip("gtkwave not found")
+
+    vcd_path = str(tmp_path / "interop.vcd")
+    cpp_csv_path = str(tmp_path / "cpp_output.csv")
+    gtk_csv_path = str(tmp_path / "gtkwave_output.csv")
+
+    # Run the C++ interop executable to produce VCD and reference CSV
+    result = subprocess.run(
+        [exe, vcd_path, cpp_csv_path],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"interop failed: {result.stderr}"
+
+    # Run GTKWave with TCL export script
+    tcl_script = os.path.join(os.path.dirname(__file__), "gtkwave_export.tcl")
+    env = os.environ.copy()
+    env["GTKWAVE_CSV_OUT"] = gtk_csv_path
+
+    # Use xvfb-run for headless operation if available, otherwise run directly
+    if shutil.which("xvfb-run"):
+        cmd = ["xvfb-run", "gtkwave", vcd_path, "-S", tcl_script]
+    else:
+        cmd = ["gtkwave", vcd_path, "-S", tcl_script]
+
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, env=env, timeout=30
+    )
+    assert result.returncode == 0, f"gtkwave failed: {result.stderr}"
+
+    # Compare CSVs
+    cpp_rows = parse_csv(cpp_csv_path)
+    gtk_rows = parse_csv(gtk_csv_path)
+
+    assert cpp_rows[0] == gtk_rows[0], (
+        f"Header mismatch:\n  C++:     {cpp_rows[0]}\n  gtkwave: {gtk_rows[0]}"
+    )
+    assert len(cpp_rows) == len(gtk_rows), (
+        f"Row count mismatch: C++ has {len(cpp_rows)}, gtkwave has {len(gtk_rows)}"
+    )
+
+    for i, (cpp_row, gtk_row) in enumerate(zip(cpp_rows[1:], gtk_rows[1:]), 1):
+        assert len(cpp_row) == len(gtk_row), (
+            f"Row {i}: column count mismatch"
+        )
+        for j, (c, g) in enumerate(zip(cpp_row, gtk_row)):
+            assert values_equal(c, g), (
+                f"Row {i}, col {j} ({cpp_rows[0][j]}): "
+                f"C++={c!r} != gtkwave={g!r}"
             )

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1,11 +1,11 @@
-/*  
+/*
  *  C++ VCD Tracer Library Tests
  *
  *  For more information see https://github.com/nakane1chome/cpp-vcd-tracer
  *
  * Copyright (c) 2022, Philip Mulholland
  * All rights reserved.
- * 
+ *
  * Using the  BSD 3-Clause License
  *
  * See LICENSE for license details.
@@ -87,7 +87,7 @@ TEST_CASE("VCD Integer Value", "VcdValue") {
         {
             std::ostringstream dump_out;
             (void)my_dumper(dump_out, true);
-            REQUIRE(dump_out.str() == "b010101010 vv\n");
+            REQUIRE(dump_out.str() == "b10101010 vv\n");
         }
 
         test_var.undriven();
@@ -208,12 +208,12 @@ TEST_CASE("VCD Integer Value", "VcdValue") {
         {
             std::ostringstream dump_out;
             (void)my_dumper(dump_out, true);
-            REQUIRE(dump_out.str() == "b01101010101 vv\n");
+            REQUIRE(dump_out.str() == "b1101010101 vv\n");
         }
     }
 
     {
-        vcd_tracer::value<unsigned int, 17> test_var(0x1DEAD);
+        vcd_tracer::value<unsigned int, 17> test_var(0x05A5A);
 
         {
             std::ostringstream dump_out;
@@ -229,8 +229,8 @@ TEST_CASE("VCD Integer Value", "VcdValue") {
         {
             std::ostringstream dump_out;
             (void)my_dumper(dump_out, true);
-            // 2 LSB are compressed
-            REQUIRE(dump_out.str() == "b101111010101101 vv\n");
+            // 2 MSB are compressed
+            REQUIRE(dump_out.str() == "b101101001011010 vv\n");
         }
 
         test_var.set(0x0);
@@ -240,6 +240,41 @@ TEST_CASE("VCD Integer Value", "VcdValue") {
             (void)my_dumper(dump_out, true);
             REQUIRE(dump_out.str() == "b0 vv\n");
         }
+
+        test_var.set(0x5);
+
+        {
+            std::ostringstream dump_out;
+            (void)my_dumper(dump_out, true);
+            REQUIRE(dump_out.str() == "b101 vv\n");
+        }
+
+        test_var.set(0xA5);
+
+        {
+            std::ostringstream dump_out;
+            (void)my_dumper(dump_out, true);
+            REQUIRE(dump_out.str() == "b10100101 vv\n");
+        }
+
+        test_var.set(0x10000);
+
+        {
+            std::ostringstream dump_out;
+            (void)my_dumper(dump_out, true);
+            REQUIRE(dump_out.str() == "b10000000000000000 vv\n");
+        }
+
+        test_var.set(0x08000);
+
+        {
+            std::ostringstream dump_out;
+            (void)my_dumper(dump_out, true);
+            REQUIRE(dump_out.str() == "b1000000000000000 vv\n");
+        }
+
+
+
     }
 }
 
@@ -306,7 +341,7 @@ TEST_CASE("VCD Trace Buffer", "VcdTraceBuffer") {
                 }
             }
         }
-        REQUIRE(dump_out.str() == "b01 vv\nb010 vv\nb011 vv\nb0100 vv\nb0101 vv\nb0 vv\n");
+        REQUIRE(dump_out.str() == "b1 vv\nb10 vv\nb11 vv\nb100 vv\nb101 vv\nb0 vv\n");
     }
 }
 
@@ -506,37 +541,37 @@ TEST_CASE("VCD Top Trace Buf", "VcdTopTraceBuf") {
 
         // Write 2 values to var1, 1 value to var2
         var_1.set(0x11);
-        edata << "b010001 !\n";
+        edata << "b10001 !\n";
         seq++;
 
         edata << "#1\n";
         var_1.set(0x12);
-        edata << "b010010 !\n";
+        edata << "b10010 !\n";
         seq++;
 
         edata << "#2\n";
         var_2.set(0x21);
-        edata << "b0100001 \"\n";
+        edata << "b100001 \"\n";
         seq++;
 
         edata << "#3\n";
         var_2.set(0x22);
-        edata << "b0100010 \"\n";
+        edata << "b100010 \"\n";
         seq++;
 
         edata << "#4\n";
         var_1.set(0x13);
-        edata << "b010011 !\n";
+        edata << "b10011 !\n";
         seq++;
 
         edata << "#5\n";
         var_1.set(0x14);
-        edata << "b010100 !\n";
+        edata << "b10100 !\n";
         seq++;
 
         edata << "#6\n";
         var_2.set(0x23);
-        edata << "b0100011 \"\n";
+        edata << "b100011 \"\n";
 
         edata << "#10\n";
 
@@ -546,4 +581,30 @@ TEST_CASE("VCD Top Trace Buf", "VcdTopTraceBuf") {
 
         REQUIRE(data.str() == edata.str());
     }
+}
+
+
+
+TEST_CASE("VCD GitHub Issue 5", "VcdIssue5") {
+    vcd_tracer::value<uint16_t> sig;
+    vcd_tracer::top dumper("top");
+    {
+        vcd_tracer::module mod(dumper.root, "dut");
+        mod.elaborate(sig, "val");
+    }
+
+    std::ostringstream header;
+    dumper.finalize_header(header, std::chrono::system_clock::from_time_t(0));
+    //REQUIRE(header.str() == EXPECTED_HEADER);
+
+    std::ostringstream data;
+    std::ostringstream edata;
+
+    sig.set(uint16_t(0xCDBC));  // 16-bit binary: 1100110110111100
+    edata << "b1100110110111100 !\n";
+    dumper.time_update_abs(data, std::chrono::nanoseconds{10});
+    edata << "#10\n";
+
+    REQUIRE(data.str() == edata.str());
+
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -33,12 +33,12 @@ std::string GenerateVcdKey(unsigned int number)// NOLINT(misc-no-recursion)
 
 TEST_CASE("VCD identifiers are created", "[GenerateVcdKey]") {
     REQUIRE(GenerateVcdKey(0) == "!");
-    REQUIRE(GenerateVcdKey(8) == ")");
-    REQUIRE(GenerateVcdKey(89) == "z");
-    REQUIRE(GenerateVcdKey(90) == "!!");
-    REQUIRE(GenerateVcdKey(91) == "!\"");
-    REQUIRE(GenerateVcdKey(179) == "!z");
-    REQUIRE(GenerateVcdKey(180) == "\"!");
+    REQUIRE(GenerateVcdKey(8) == "+");
+    REQUIRE(GenerateVcdKey(87) == "z");
+    REQUIRE(GenerateVcdKey(88) == "!!");
+    REQUIRE(GenerateVcdKey(89) == "!\"");
+    REQUIRE(GenerateVcdKey(175) == "!z");
+    REQUIRE(GenerateVcdKey(176) == "\"!");
 }
 
 TEST_CASE("VCD Integer Value", "VcdValue") {

--- a/test/vcd_to_csv.py
+++ b/test/vcd_to_csv.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+import csv
+import sys
+from vcd.reader import tokenize, TokenKind
+
+def vcd_to_csv(vcd_path, csv_path):
+
+    signals = {}
+    id_to_name = {}
+    current_values = {}
+    rows = []
+    current_time = 0
+
+    with open(vcd_path, "rb") as f:
+
+        for token in tokenize(f):
+
+            if token.kind == TokenKind.VAR:
+                var = token.data
+                name = var.reference
+                id_code = var.id_code
+
+                signals[id_code] = name
+                id_to_name[id_code] = name
+                current_values[name] = None
+
+            elif token.kind == TokenKind.CHANGE_TIME:
+
+                if rows or current_time != 0:
+                    rows.append((current_time, current_values.copy()))
+
+                current_time = token.data
+
+            elif token.kind == TokenKind.CHANGE_SCALAR:
+
+                id_code = token.data.id_code
+                value = token.data.value
+
+                name = id_to_name[id_code]
+                current_values[name] = value
+
+            elif token.kind == TokenKind.CHANGE_VECTOR:
+
+                id_code = token.data.id_code
+                value = token.data.value
+
+                name = id_to_name[id_code]
+                current_values[name] = value
+
+            elif token.kind == TokenKind.CHANGE_REAL:
+
+                id_code = token.data.id_code
+                value = token.data.value
+
+                name = id_to_name[id_code]
+                current_values[name] = value
+
+    rows.append((current_time, current_values.copy()))
+
+    signal_names = sorted(current_values.keys())
+
+    with open(csv_path, "w", newline="") as csvfile:
+
+        writer = csv.writer(csvfile)
+
+        writer.writerow(["time"] + signal_names)
+
+        for time, values in rows:
+
+            row = [time]
+            for sig in signal_names:
+                row.append(values.get(sig))
+
+            writer.writerow(row)
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 3:
+        print("usage: python vcd_to_csv.py input.vcd output.csv")
+        sys.exit(1)
+
+    vcd_to_csv(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
PR to apply patch from <https://github.com/nakane1chome/cpp-vcd-tracer/issues/5>

- Compression of leading 1's
- Add better tests for compression
- Add issue <https://github.com/nakane1chome/cpp-vcd-tracer/issues/5> example as test
- Add interoperability test that writes VCD and CSV, then converts VCD to CSV with pyvcd and GTKWave and compares input and output CSVs.
